### PR TITLE
Game over

### DIFF
--- a/src/scenes/GameOver.js
+++ b/src/scenes/GameOver.js
@@ -9,14 +9,22 @@ export default class GameOver extends Phaser.Scene {
   }
 
   create() {
+    const screenCenterX =
+      this.cameras.main.worldView.x + this.cameras.main.width / 2;
+    const screenCenterY =
+      this.cameras.main.worldView.y + this.cameras.main.height / 2;
+
     this.gameOverText = this.add
-      .text(200, 200, "GAME OVER", { fontSize: 48 })
-      .setDepth(1);
+      .text(screenCenterX, screenCenterY - 20, "GAME OVER", { fontSize: 48 })
+      .setDepth(1)
+      .setOrigin(0.5);
+
     this.scoreText = this.add
-      .text(200, 260, `Your score is ${score}`, {
+      .text(screenCenterX, screenCenterY + 40, `Your score is ${score}`, {
         fontSize: 24,
       })
-      .setDepth(1);
+      .setDepth(1)
+      .setOrigin(0.5);
   }
 
   update() {}

--- a/src/scenes/Play.js
+++ b/src/scenes/Play.js
@@ -178,7 +178,14 @@ export default class Play extends Phaser.Scene {
     hunterBullet.destroy();
 
     if (this.health.decreaseHealth()) {
-      this.scene.start("gameover");
+      player.play("explode").setScale(1);
+      this.hunters.getChildren().forEach((hunter) => {
+        hunter.destroy();
+      });
+      this.hunterShootTimers.forEach((timer) => {
+        timer.remove(false);
+      });
+      this.time.delayedCall(2000, () => this.scene.start("gameover"));
     }
   }
 


### PR DESCRIPTION
When life count gets to 0:
- Destroy player, play explosion animation
- Destroy hunters (there's currently one rogue hunter left)
- Make hunters stop shooting
- Add delay of 3 seconds before moving to game over scene

Game over screen:
- Centre text